### PR TITLE
Support for HPOS / Update to Minimum Version of WooCommerce Supported to 6.9.1 from 7.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 2.3.5 =
+* Added: Support for WooCommerce HPOS.
+* Fixed: WooCommerce Blocks Compatibility Issues with WooCommerce 7.0 to 6.9.1.
 = 2.3.4 = 
 * Fix: Webhook Handler Acknowledgement.
 = 2.3.2 =

--- a/composer.lock
+++ b/composer.lock
@@ -213,16 +213,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
                 "shasum": ""
             },
             "require": {
@@ -263,9 +263,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-12-10T21:03:43+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -554,16 +554,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "9.2.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
                 "shasum": ""
             },
             "require": {
@@ -619,7 +619,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
             },
             "funding": [
                 {
@@ -627,7 +628,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-09-19T04:57:46+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -872,16 +873,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.8",
+            "version": "9.6.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
-                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
                 "shasum": ""
             },
             "require": {
@@ -896,7 +897,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-code-coverage": "^9.2.28",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -955,7 +956,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
             },
             "funding": [
                 {
@@ -971,7 +972,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-11T05:14:45+00:00"
+            "time": "2023-12-01T16:55:19+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1479,16 +1480,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
                 "shasum": ""
             },
             "require": {
@@ -1531,7 +1532,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
             },
             "funding": [
                 {
@@ -1539,7 +1540,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-08-02T09:26:13+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1939,16 +1940,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
                 "shasum": ""
             },
             "require": {
@@ -1958,7 +1959,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -1977,35 +1978,58 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T12:32:31+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -2034,7 +2058,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -2042,7 +2066,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",
@@ -2141,16 +2165,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.5",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
-                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/224e4a1329c03d8bad520e3fc4ec980034a4b212",
+                "reference": "224e4a1329c03d8bad520e3fc4ec980034a4b212",
                 "shasum": ""
             },
             "require": {
@@ -2197,7 +2221,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2023-03-30T23:39:05+00:00"
+            "time": "2023-08-19T14:25:08+00:00"
         }
     ],
     "aliases": [],

--- a/i18n/languages/rave-woocommerce-payment-gateway.pot
+++ b/i18n/languages/rave-woocommerce-payment-gateway.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the MIT License.
 msgid ""
 msgstr ""
-"Project-Id-Version: Flutterwave WooCommerce 2.3.2\n"
+"Project-Id-Version: Flutterwave WooCommerce 2.3.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/rave-woocommerce-payment-gateway\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-05-19T18:16:02+00:00\n"
+"POT-Creation-Date: 2023-12-24T22:36:44+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: rave-woocommerce-payment-gateway\n"
@@ -37,96 +37,96 @@ msgstr ""
 msgid "http://flutterwave.com/us"
 msgstr ""
 
-#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:137
+#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:156
 msgid "Visa"
 msgstr ""
 
-#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:141
+#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:160
 msgid "American Express"
 msgstr ""
 
-#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:145
+#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:164
 msgid "Mastercard"
 msgstr ""
 
-#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:152
+#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:171
 msgctxt "Name of credit card"
 msgid "Discover"
 msgstr ""
 
-#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:156
+#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:175
 msgid "JCB"
 msgstr ""
 
-#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:160
+#: includes/blocks/class-flutterwave-wc-gateway-blocks-support.php:179
 msgid "Diners"
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:46
+#: includes/class-flw-wc-payment-gateway-event-handler.php:64
 msgid "Payment initialized via Flutterwave"
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:48
+#: includes/class-flw-wc-payment-gateway-event-handler.php:66
 msgid "Your transaction reference: "
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:66
+#: includes/class-flw-wc-payment-gateway-event-handler.php:83
 msgid "Attention: New order has been placed on hold because of incorrect payment amount or currency. Please, look into it."
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:67
+#: includes/class-flw-wc-payment-gateway-event-handler.php:84
 msgid "Amount paid: "
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:67
+#: includes/class-flw-wc-payment-gateway-event-handler.php:84
 msgid "Order amount: "
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:67
+#: includes/class-flw-wc-payment-gateway-event-handler.php:84
 msgid " Reference: "
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:107
+#: includes/class-flw-wc-payment-gateway-event-handler.php:124
 msgid "The payment failed on Flutterwave"
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:112
+#: includes/class-flw-wc-payment-gateway-event-handler.php:129
 msgid "Reason for Failure : "
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:124
+#: includes/class-flw-wc-payment-gateway-event-handler.php:141
 msgid "Confirming payment on Flutterwave"
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:134
+#: includes/class-flw-wc-payment-gateway-event-handler.php:151
 msgid "An error occured while confirming payment on Flutterwave"
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:139
+#: includes/class-flw-wc-payment-gateway-event-handler.php:156
 msgid "Attention: New order has been placed on hold because we could not confirm the payment. Please, look into it."
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:155
+#: includes/class-flw-wc-payment-gateway-event-handler.php:172
 msgid "The customer clicked on the cancel button on Checkout."
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:157
+#: includes/class-flw-wc-payment-gateway-event-handler.php:174
 msgid "Attention: Customer clicked on the cancel button on the payment gateway. We have updated the order to cancelled status. "
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:158
+#: includes/class-flw-wc-payment-gateway-event-handler.php:175
 msgid "Please, confirm from the order notes that there is no note of a successful transaction. If there is, this means that the user was debited and you either have to give value for the transaction or refund the customer."
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:172
+#: includes/class-flw-wc-payment-gateway-event-handler.php:189
 msgid "The payment didn't return a valid response. It could have timed out or abandoned by the customer on Flutterwave"
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:177
+#: includes/class-flw-wc-payment-gateway-event-handler.php:194
 msgid "Attention: New order has been placed on hold because we could not get a definite response from the payment gateway. Kindly contact the Rave support team at hi@flutterwave.com to confirm the payment."
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway-event-handler.php:178
+#: includes/class-flw-wc-payment-gateway-event-handler.php:195
 msgid "Payment Reference: "
 msgstr ""
 
@@ -252,7 +252,7 @@ msgstr ""
 
 #: includes/class-flw-wc-payment-gateway.php:329
 msgctxt "payment_options"
-msgid "Default"
+msgid "All"
 msgstr ""
 
 #: includes/class-flw-wc-payment-gateway.php:330
@@ -331,11 +331,20 @@ msgid "Check the box if you want to disable barter."
 msgstr ""
 
 #. translators: %s: url
-#: includes/class-flw-wc-payment-gateway.php:448
+#: includes/class-flw-wc-payment-gateway.php:452
 msgid "Flutterwave is enabled, but the API keys are not set. Please <a href=\"%s\">set your Flutterwave API keys</a> to be able to accept payments."
 msgstr ""
 
-#: includes/class-flw-wc-payment-gateway.php:539
+#. translators: %s: shop cart url
+#: includes/class-flw-wc-payment-gateway.php:489
+msgid "Sorry, your session has expired. <a href=\"%s\" class=\"wc-backward\">Return to shop</a>"
+msgstr ""
+
+#: includes/class-flw-wc-payment-gateway.php:503
+msgid "We were unable to process your order, please try again."
+msgstr ""
+
+#: includes/class-flw-wc-payment-gateway.php:550
 msgid "Order Payment"
 msgstr ""
 
@@ -345,7 +354,7 @@ msgstr ""
 
 #. translators: $1. Minimum WooCommerce version. $2. Current WooCommerce version.
 #: includes/notices/class-flw-wc-payment-gateway-notices.php:32
-msgid "Flutterwave WooCommerce requires WooCommerce %1$s or greater to be installed and active. WooCommerce %2$s is no longer supported."
+msgid "Flutterwave WooCommerce requires WooCommerce %1$s or greater to be installed and active. kindly upgrade to a higher version of WooCommerce or downgrade to a lower version of Flutterwave WooCommerce that supports WooCommerce version %2$s."
 msgstr ""
 
 #. Translators: %s Plugin name.
@@ -366,19 +375,27 @@ msgstr ""
 msgid "Install WooCommerce"
 msgstr ""
 
+#: build/index.js:1
 #: client/blocks/payment-method/index.js:19
+#: build/index.js:102
 msgid "You may be redirected to a secure page to complete your payment."
 msgstr ""
 
+#: build/index.js:1
 #: client/blocks/payment-method/index.js:32
+#: build/index.js:115
 msgid "Flutterwave"
 msgstr ""
 
+#: build/index.js:1
 #: client/blocks/payment-method/index.js:38
+#: build/index.js:121
 msgid "Proceed to Flutterwave"
 msgstr ""
 
+#: build/index.js:1
 #: client/blocks/payment-method/index.js:44
+#: build/index.js:127
 msgid "Payment via Flutterwave"
 msgstr ""
 

--- a/includes/blocks/class-flutterwave-wc-gateway-blocks-support.php
+++ b/includes/blocks/class-flutterwave-wc-gateway-blocks-support.php
@@ -43,19 +43,19 @@ final class Flutterwave_WC_Gateway_Blocks_Support extends AbstractPaymentMethodT
 	 * @inheritDoc
 	 */
 	public function initialize() {
-    $this->settings = get_option( 'woocommerce_rave_settings', array() );
+		$this->settings = get_option( 'woocommerce_rave_settings', array() );
 
-    if( version_compare( WC_VERSION, '6.9.1', '<' )) {
-      //For backwards compatibility.
-      if (!class_exists('FLW_WC_Payment_Gateway')){
-        require_once dirname( FLW_WC_PLUGIN_FILE ). '/includes/class-flw-wc-payment-gateway.php';
-      }
+		if ( version_compare( WC_VERSION, '6.9.1', '<' ) ) {
+			// For backwards compatibility.
+			if ( ! class_exists( 'FLW_WC_Payment_Gateway' ) ) {
+				require_once dirname( FLW_WC_PLUGIN_FILE ) . '/includes/class-flw-wc-payment-gateway.php';
+			}
 
-		  $this->gateway  = new FLW_WC_Payment_Gateway();
-    } else {
-      $gateways = WC()->payment_gateways->payment_gateways();
-      $this->gateway = $gateways[$this->name];
-    }
+			$this->gateway = new FLW_WC_Payment_Gateway();
+		} else {
+			$gateways      = WC()->payment_gateways->payment_gateways();
+			$this->gateway = $gateways[ $this->name ];
+		}
 	}
 
 	/**
@@ -63,14 +63,14 @@ final class Flutterwave_WC_Gateway_Blocks_Support extends AbstractPaymentMethodT
 	 *
 	 * @return boolean
 	 */
-  public function is_active(): bool {
-    if( version_compare( WC_VERSION, '6.9.0', '>')) {
-      $gateways = WC()->payment_gateways->payment_gateways();
+	public function is_active(): bool {
+		if ( version_compare( WC_VERSION, '6.9.0', '>' ) ) {
+			$gateways = WC()->payment_gateways->payment_gateways();
 
-      if(!isset( $gateways[$this->name] )) {
-        return false;
-      }
-    }
+			if ( ! isset( $gateways[ $this->name ] ) ) {
+				return false;
+			}
+		}
 
 		return $this->gateway->is_available();
 	}

--- a/includes/blocks/class-flutterwave-wc-gateway-blocks-support.php
+++ b/includes/blocks/class-flutterwave-wc-gateway-blocks-support.php
@@ -35,7 +35,7 @@ final class Flutterwave_WC_Gateway_Blocks_Support extends AbstractPaymentMethodT
 	 *
 	 * @var WC_Payment_Gateway
 	 */
-	protected WC_Payment_Gateway $gateway;
+	protected $gateway;
 
 	/**
 	 * Initialize the Block.
@@ -43,8 +43,19 @@ final class Flutterwave_WC_Gateway_Blocks_Support extends AbstractPaymentMethodT
 	 * @inheritDoc
 	 */
 	public function initialize() {
-		$this->settings = get_option( 'woocommerce_rave_settings', array() );
-		$this->gateway  = new FLW_WC_Payment_Gateway();
+    $this->settings = get_option( 'woocommerce_rave_settings', array() );
+
+    if( version_compare( WC_VERSION, '6.9.1', '<' )) {
+      //For backwards compatibility.
+      if (!class_exists('FLW_WC_Payment_Gateway')){
+        require_once dirname( FLW_WC_PLUGIN_FILE ). '/includes/class-flw-wc-payment-gateway.php';
+      }
+
+		  $this->gateway  = new FLW_WC_Payment_Gateway();
+    } else {
+      $gateways = WC()->payment_gateways->payment_gateways();
+      $this->gateway = $gateways[$this->name];
+    }
 	}
 
 	/**
@@ -52,7 +63,15 @@ final class Flutterwave_WC_Gateway_Blocks_Support extends AbstractPaymentMethodT
 	 *
 	 * @return boolean
 	 */
-	public function is_active(): bool {
+  public function is_active(): bool {
+    if( version_compare( WC_VERSION, '6.9.0', '>')) {
+      $gateways = WC()->payment_gateways->payment_gateways();
+
+      if(!isset( $gateways[$this->name] )) {
+        return false;
+      }
+    }
+
 		return $this->gateway->is_available();
 	}
 

--- a/includes/class-flutterwave.php
+++ b/includes/class-flutterwave.php
@@ -74,7 +74,7 @@ final class Flutterwave {
 		$this->define( 'FLW_WC_PLUGIN_DIR', plugin_dir_path( FLW_WC_PLUGIN_FILE ) );
 		$this->define( 'FLW_WC_DIR_PATH', plugin_dir_path( FLW_WC_PLUGIN_FILE ) );
 		$this->define( 'FLW_WC_VERSION', $this->version );
-		$this->define( 'FLW_WC_MIN_WC_VER', '7.1' );
+		$this->define( 'FLW_WC_MIN_WC_VER', '6.9.1' );
 		$this->define( 'FLW_WC_URL', trailingslashit( plugins_url( '/', FLW_WC_PLUGIN_FILE ) ) );
 		$this->define( 'FLW_WC_EPSILON', 0.01 );
 	}

--- a/includes/notices/class-flw-wc-payment-gateway-notices.php
+++ b/includes/notices/class-flw-wc-payment-gateway-notices.php
@@ -28,7 +28,7 @@ class FLW_WC_Payment_Gateway_Notices {
 	 * @return void
 	 */
 	public function woocommerce_wc_not_supported() {
-    /* translators: $1. Minimum WooCommerce version. $2. Current WooCommerce version. */
+		/* translators: $1. Minimum WooCommerce version. $2. Current WooCommerce version. */
 		echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Flutterwave WooCommerce requires WooCommerce %1$s or greater to be installed and active. kindly upgrade to a higher version of WooCommerce or downgrade to a lower version of Flutterwave WooCommerce that supports WooCommerce version %2$s.', 'rave-woocommerce-payment-gateway' ), esc_attr( FLW_WC_MIN_WC_VER ), esc_attr( WC_VERSION ) ) . '</strong></p></div>';
-  } 
+	}
 }

--- a/includes/notices/class-flw-wc-payment-gateway-notices.php
+++ b/includes/notices/class-flw-wc-payment-gateway-notices.php
@@ -28,8 +28,7 @@ class FLW_WC_Payment_Gateway_Notices {
 	 * @return void
 	 */
 	public function woocommerce_wc_not_supported() {
-		/* translators: $1. Minimum WooCommerce version. $2. Current WooCommerce version. */
-		echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Flutterwave WooCommerce requires WooCommerce %1$s or greater to be installed and active. WooCommerce %2$s is no longer supported.', 'rave-woocommerce-payment-gateway' ), esc_attr( FLW_WC_MIN_WC_VER ), esc_attr( WC_VERSION ) ) . '</strong></p></div>';
-
-	}
+    /* translators: $1. Minimum WooCommerce version. $2. Current WooCommerce version. */
+		echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Flutterwave WooCommerce requires WooCommerce %1$s or greater to be installed and active. kindly upgrade to a higher version of WooCommerce or downgrade to a lower version of Flutterwave WooCommerce that supports WooCommerce version %2$s.', 'rave-woocommerce-payment-gateway' ), esc_attr( FLW_WC_MIN_WC_VER ), esc_attr( WC_VERSION ) ) . '</strong></p></div>';
+  } 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rave-woocommerce-payment-gateway",
-	"version": "2.3.2",
+	"version": "2.3.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rave-woocommerce-payment-gateway",
-			"version": "2.3.2",
+			"version": "2.3.4",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/rave-woocommerce-payment-gateway.php
+++ b/rave-woocommerce-payment-gateway.php
@@ -60,11 +60,14 @@ function flutterwave_woocommerce_blocks_support() {
 add_action( 'woocommerce_blocks_loaded', 'flutterwave_woocommerce_blocks_support' );
 
 
-add_action( 'before_woocommerce_init', function() {
-	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
-		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+add_action(
+	'before_woocommerce_init',
+	function() {
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+		}
 	}
-} );
+);
 
 
 /**

--- a/rave-woocommerce-payment-gateway.php
+++ b/rave-woocommerce-payment-gateway.php
@@ -9,8 +9,8 @@
  * License: MIT License
  * Text Domain: rave-woocommerce-payment-gateway
  * Domain Path: i18n/languages
- * WC requires at least:   7.1
- * WC tested up to:        8.2.1
+ * WC requires at least:   6.9.1
+ * WC tested up to:        8.4.0
  * Requires at least:      5.6
  * Requires PHP:           7.4
  *
@@ -58,6 +58,14 @@ function flutterwave_woocommerce_blocks_support() {
 
 // add woocommerce block support.
 add_action( 'woocommerce_blocks_loaded', 'flutterwave_woocommerce_blocks_support' );
+
+
+add_action( 'before_woocommerce_init', function() {
+	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+	}
+} );
+
 
 /**
  * Add the Settings link to the plugin

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: theflutterwave
 Tags: fintech,flutterwave, woocommerce, payments, nigeria, mastercard, visa, target,Naira,payments,verve,donation,church,shop,store, ghana, kenya, international, mastercard, visa
 Requires at least: 3.1
-Tested up to: 6.3.2
+Tested up to: 6.4.2
 Stable tag: 2.3.4
 License: MIT
 License URI: https://github.com/Flutterwave/Woocommerce/blob/master/LICENSE
@@ -96,6 +96,9 @@ By contributing to the Flutterwave WooCommerce, you agree that your contribution
 1. You need to open an account on [Flutterwave for Business](https://dashboard.flutterwave.com)
 
 == Changelog ==
+= 2.3.5 =
+* Added: Support for HPOS.
+* Fixed: compatibility with WooCommerce 7.1 to 6.9.1
 = 2.3.4 = 
 * Fix: Webhook Handler Acknowledgement.
 = 2.3.2 =


### PR DESCRIPTION
These changes fix the following issues:

- https://wordpress.org/support/topic/hpos-compatibility-59/
- https://wordpress.org/support/topic/compatibility-with-woocommerce-cart-and-checkout-blocks/

<img width="1248" alt="image" src="https://github.com/Flutterwave/Woocommerce-v2/assets/129767063/838431b3-75ec-4b9d-b835-522cb6c29f99">
<img width="523" alt="image" src="https://github.com/Flutterwave/Woocommerce-v2/assets/129767063/7fd8832e-f092-442e-8aad-698418e5f4a6">

<img width="1225" alt="image" src="https://github.com/Flutterwave/Woocommerce-v2/assets/129767063/eb869d7c-05e3-405f-a8e8-c1a81d4d8bf2">

