### PR TITLE
Ensure proper handling of invalid transaction references in webhook handler when WooCommerce HPOS is enabled.

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -34,6 +34,7 @@ build/*.map
 phpunit.xml.dist
 playwright.config.js
 .gitpod.yml
+.gitpod.Dockerfile
 /node_modules
 /vendor
 rave-woocommerce-payment-gateway.zip

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+# You can find the new timestamped tags here: https://hub.docker.com/r/gitpod/workspace-full/tags
+FROM gitpod/workspace-full:2022-05-08-14-31-53
+
+# Change your version here
+RUN sudo update-alternatives --set php $(which php7.4)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,6 @@
-
+image:
+    file: .gitpod.Dockerfile
+    
 tasks:
   - init: open ./tests/PHPUnit/README.md
 

--- a/includes/class-flw-wc-payment-gateway.php
+++ b/includes/class-flw-wc-payment-gateway.php
@@ -666,11 +666,11 @@ class FLW_WC_Payment_Gateway extends WC_Payment_Gateway {
 			$event_data = $event->data;
 
 			// check if transaction reference starts with WOOC on hpos enabled.
-			if (substr($event_data->tx_ref, 0, 4) !== "WOOC") {
+			if ( substr( $event_data->tx_ref, 0, 4 ) !== 'WOOC' ) {
 				wp_send_json(
 					array(
 						'status'  => 'failed',
-						'message' => "The transaction reference " . $event_data->tx_ref . " is not a Flutterwave WooCommerce Generated transaction",
+						'message' => 'The transaction reference ' . $event_data->tx_ref . ' is not a Flutterwave WooCommerce Generated transaction',
 					),
 					WP_Http::OK
 				);

--- a/includes/class-flw-wc-payment-gateway.php
+++ b/includes/class-flw-wc-payment-gateway.php
@@ -665,6 +665,17 @@ class FLW_WC_Payment_Gateway extends WC_Payment_Gateway {
 			$event_type = $event->event;
 			$event_data = $event->data;
 
+			// check if transaction reference starts with WOOC on hpos enabled.
+			if (substr($event_data->tx_ref, 0, 4) !== "WOOC") {
+				wp_send_json(
+					array(
+						'status'  => 'failed',
+						'message' => "The transaction reference " . $event_data->tx_ref . " is not a Flutterwave WooCommerce Generated transaction",
+					),
+					WP_Http::OK
+				);
+			}
+
 			$txn_ref  = sanitize_text_field( $event_data->tx_ref );
 			$o        = explode( '_', $txn_ref );
 			$order_id = intval( $o[1] );

--- a/tests/PHPUnit/test-flw-wc-payment-gateway.php
+++ b/tests/PHPUnit/test-flw-wc-payment-gateway.php
@@ -97,6 +97,31 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the gateway webhook on invalid transaction reference
+	 * 
+	 */
+	public function test_webhook_transaction_not_found() {
+		$hash = "a4a6e4c86fc1347a48eeab1171f7fea1a10eecbac223b86db3b3e3e134fefa40";
+		$data = [ "event" => "charge.completed", "data" => ["tx_ref" => "Rave-Pages846040622798"]];
+
+		$webhook_url = WC()->api_request_url( 'Flw_WC_Payment_Webhook' );
+
+		//make a request to the webhook url.
+		$response = wp_remote_post( $webhook_url, array(
+			'method'      => 'POST',
+			'headers'     => array(
+				'Content-Type' => 'application/json',
+				'Authorization' => 'Bearer '.getenv('SECRET_KEY'),
+				'VERIF-HASH' => $hash
+			),
+			'body'        => wp_json_encode( $data )
+		) );
+
+
+		$this->assertEquals( WP_Http::OK, wp_remote_retrieve_response_code( $response ) );
+	}
+
+	/**
 	 * Tests the gateway webhook.
 	 *
 	 * @dataProvider webhook_204_provider


### PR DESCRIPTION
## Issue

When WooCommerce HPOS is enabled, invalid transaction references return a response of status 500.

## After Fix
<img width="844" alt="image" src="https://github.com/Flutterwave/Woocommerce-v2/assets/129767063/05ad9ea6-1a9a-4b0c-af22-0b9159257fc5">
