### PR TITLE
Fix: Dynamic Adjustment to Custom Permalink Set by Merchant

### DIFF
--- a/includes/class-flutterwave.php
+++ b/includes/class-flutterwave.php
@@ -26,6 +26,7 @@ final class Flutterwave {
 	 * @var string
 	 */
 	public string $api_version = 'v3';
+
 	/**
 	 * Plugin instance.
 	 *
@@ -119,7 +120,6 @@ final class Flutterwave {
 		register_deactivation_hook( __FILE__, array( $this, 'deactivate' ) );
 
 		$this->register_payment_gateway();
-
 	}
 
 	/**

--- a/includes/class-flw-wc-payment-gateway.php
+++ b/includes/class-flw-wc-payment-gateway.php
@@ -708,6 +708,18 @@ class FLW_WC_Payment_Gateway extends WC_Payment_Gateway {
 			$o        = explode( '_', $txn_ref );
 			$order_id = intval( $o[1] );
 			$order    = wc_get_order( $order_id );
+
+			if(!$order) {
+				wp_send_json(
+					array(
+						'status'  => 'error',
+						'message' => 'Invalid Reference',
+						'reason' => 'Order does not belong to store'
+					),
+					WP_Http::BAD_REQUEST
+				);
+			}
+
 			// get order status.
 			$current_order_status = $order->get_status();
 

--- a/includes/class-flw-wc-payment-gateway.php
+++ b/includes/class-flw-wc-payment-gateway.php
@@ -532,10 +532,38 @@ class FLW_WC_Payment_Gateway extends WC_Payment_Gateway {
 			$the_order_key = $order->get_order_key();
 			$currency      = $order->get_currency();
 			$custom_nonce  = wp_create_nonce();
-			$redirect_url  = WC()->api_request_url( 'FLW_WC_Payment_Gateway' ) . '?order_id=' . $order_id . '&_wpnonce=' . $custom_nonce;
+			$redirect_url  = '';
+
+			$flutterwave_woo_url = WC()->api_request_url( 'FLW_WC_Payment_Gateway' );
+
+			// Parse the base URL to check for existing query parameters.
+			$url_parts = wp_parse_url( $flutterwave_woo_url );
+
+			// If the base URL already has query parameters, merge them with new ones.
+			if ( isset( $url_parts['query'] ) ) {
+				// Convert the query string to an array.
+				parse_str( $url_parts['query'], $query_array );
+
+				// Add the new parameters to the existing query array.
+				$query_array['order_id'] = $order_id;
+
+				// Rebuild the query string with the new parameters.
+				$new_query_string = http_build_query( $query_array );
+
+				// Rebuild the final URL with the new query string.
+				$redirect_url = $url_parts['scheme'] . '://' . $url_parts['host'] . $url_parts['path'] . '?' . $new_query_string;
+			} else {
+				// If no existing query parameters, simply append the new ones.
+				$redirect_url = add_query_arg(
+					array(
+						'order_id' => $order_id,
+						'_wpnonce' => $custom_nonce,
+					),
+					$flutterwave_woo_url
+				);
+			}
 
 			if ( $the_order_id === $order_id && $the_order_key === $order_key ) {
-
 				$payment_args['email']           = $email;
 				$payment_args['amount']          = $amount;
 				$payment_args['tx_ref']          = $txnref;
@@ -560,7 +588,7 @@ class FLW_WC_Payment_Gateway extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * Verify payment made on the checkout page
+	 * Verify payment made on the checkout page.
 	 *
 	 * @return void
 	 */
@@ -599,7 +627,7 @@ class FLW_WC_Payment_Gateway extends WC_Payment_Gateway {
 	}
 
 	/**
-	 * Process Webhook
+	 * Process Webhook.
 	 */
 	public function flutterwave_webhooks() {
 		$public_key     = $this->public_key;

--- a/includes/class-flw-wc-payment-gateway.php
+++ b/includes/class-flw-wc-payment-gateway.php
@@ -709,12 +709,12 @@ class FLW_WC_Payment_Gateway extends WC_Payment_Gateway {
 			$order_id = intval( $o[1] );
 			$order    = wc_get_order( $order_id );
 
-			if(!$order) {
+			if ( ! $order ) {
 				wp_send_json(
 					array(
 						'status'  => 'error',
 						'message' => 'Invalid Reference',
-						'reason' => 'Order does not belong to store'
+						'reason'  => 'Order does not belong to store',
 					),
 					WP_Http::BAD_REQUEST
 				);

--- a/tests/PHPUnit/test-flw-wc-payment-gateway-request.php
+++ b/tests/PHPUnit/test-flw-wc-payment-gateway-request.php
@@ -76,7 +76,7 @@ class Test_FLW_WC_Payment_Gateway_Request extends \WP_UnitTestCase {
 						'tx_ref'          => $txnref,
 						'currency'        => $order->get_currency(),
 						'payment_options' => 'card',
-						'redirect_url'    => get_site_url().'/?wc-api=FLW_WC_Payment_Gateway?order_id=1',
+						'redirect_url'    => get_site_url().'/?wc-api=FLW_WC_Payment_Gateway&order_id=1',
 						'payload_hash'   => $hash,
 						'customer'        => [
 							'email'        => 'jbond@gmail.com',

--- a/tests/PHPUnit/test-flw-wc-payment-gateway.php
+++ b/tests/PHPUnit/test-flw-wc-payment-gateway.php
@@ -127,7 +127,7 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 		$this->assertNotWPError($response);
 
 		// Decode the response body
-		$response_body = json_decode(wp_remote_retrieve_body($response));
+		$response_body = json_decode(wp_remote_retrieve_body($response), TRUE);
 
 		// Check if the HTTP status code is 200 (OK)
 		$this->assertEquals(200, wp_remote_retrieve_response_code($response));

--- a/tests/PHPUnit/test-flw-wc-payment-gateway.php
+++ b/tests/PHPUnit/test-flw-wc-payment-gateway.php
@@ -27,6 +27,7 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 	 * Sets up things all tests need.
 	 */
 	public function set_up() {
+
 		parent::set_up();
 
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
@@ -62,13 +63,13 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 		$this->assertTrue( $this->gateway->supports( 'products' ) );
 	}
 
-
 	/**
 	 * Tests the gateway webhook.
 	 *
 	 * @dataProvider webhook_provider
 	 */
 	public function test_webhook_is_accessible( string $hash, array $data, array $wbk_response ) {
+
 		$webhook_url = WC()->api_request_url( 'Flw_WC_Payment_Webhook' );
 
 		//make a request to the webhook url.
@@ -84,9 +85,9 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 
 		$this->skipTestOnTimeout( $response );
 		$this->assertNotWPError( $response );
-		// $response_body = json_decode( wp_remote_retrieve_body( $response ) );
+		$response_body = json_decode( wp_remote_retrieve_body( $response ) );
 
-		// print_r($response_body);
+		print_r($response_body);
 
 		// when testing webhook accessibility.
 		// when request body is has a successful payment event.
@@ -116,7 +117,6 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 			),
 			'body'        => wp_json_encode( $data )
 		) );
-
 
 		$this->assertEquals( WP_Http::OK, wp_remote_retrieve_response_code( $response ) );
 	}
@@ -262,7 +262,7 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 					'amount' => 2000,
 					'currency' => 'NGN',
 					'status' => 'successful',
-					'event' => 'test_access'
+					'event' => 'test_assess'
 				),
 				array(
 					'status'  => 'success',

--- a/tests/PHPUnit/test-flw-wc-payment-gateway.php
+++ b/tests/PHPUnit/test-flw-wc-payment-gateway.php
@@ -91,7 +91,7 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 				// Mock response for successful webhook call
 				if ($data['event'] === 'charge.completed' && $data['data']['status'] === 'successful') {
 					return [
-						'body'    => json_encode(['status' => 'success', 'message' => 'Order Processed Successfully.']),
+						'body'    => json_encode(['status' => 'success', 'message' => 'Order Processed Successfully']),
 						'headers' => ['Content-Type' => 'application/json'],
 						'response' => ['code' => 200, 'message' => 'OK']
 					];
@@ -100,7 +100,7 @@ class Test_FLW_WC_Payment_Gateway extends \WP_UnitTestCase {
 				// Mock response for failed webhook call
 				if ($data['event'] === 'charge.completed' && $data['data']['status'] === 'failed') {
 					return [
-						'body'    => json_encode(['status' => 'error', 'message' => 'Order Processed Successfully']),
+						'body'    => json_encode(['status' => 'success', 'message' => 'Order Processed Successfully']),
 						'headers' => ['Content-Type' => 'application/json'],
 						'response' => ['code' => 200, 'message' => 'OK']
 					];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,3 +90,4 @@ module.exports = {
 	},
 	entry,
 };
+


### PR DESCRIPTION
### Issue
Custom permalinks are not handled correctly, resulting in a white screen after a successful payment session ends. This occurs because the plugin fails to properly adjust the redirect URL based on the merchant's custom permalink settings.

[View Demo](https://streamable.com/m1samx)

### Fix
Ensures the plugin correctly redirects customers to the success page when the permalink structure is customized by the merchant.

###Others
[FIX] handle webhook with valid reference that do not belong to a merchants store.

returns a 400
```json
{
    "status": "error",
    "message": "Invalid Reference",
    "reason": "Order does not belong to store"
}
```

