### PR TITLE
FTPI-1018: Handle Trailing Zeros on Standard Request

### DIFF
--- a/includes/client/class-flw-wc-payment-gateway-request.php
+++ b/includes/client/class-flw-wc-payment-gateway-request.php
@@ -82,7 +82,7 @@ final class FLW_WC_Payment_Gateway_Request {
 	public function get_prepared_payload( \WC_Order $order, string $secret_key, bool $testing = false ): array {
 		$order_id = $order->get_id();
 		$txnref   = 'WOOC_' . $order_id . '_' . time();
-		$amount   = $order->get_total();
+		$amount   = (float) $order->get_total();
 		$currency = $order->get_currency();
 		$email    = $order->get_billing_email();
 


### PR DESCRIPTION
WooCommerce merchants are currently unable to utilize the redirect integration method on their stores. This issue stems from a bug related to the handling of amounts with trailing zeros during the checksum verification process.

![image](https://github.com/user-attachments/assets/7e507067-c559-43a5-97fe-4c85518687f8)


Issue
The presence of trailing zeros in the amount is causing the checksum validation to fail. This is due to the way WooCommerce processes and formats the amount, which impacts the hash generation.

Fix
To resolve this, cast the amount from WooCommerce to a float before generating the checksum hash. This will ensure that the trailing zeros are removed, and the hash is correctly calculated.

