### PR TITLE
Bump up wp tested version to 6.7.1 and plugin version to 2.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 2.3.6 | 01-09-2025
+Bug Fixes and Webhook Handler improvements.
+### Version Changes
+- [FIXED] Dynamic Adjustment to Custom Permalink Set by Merchant.
+- [FIXED] Redirect Payment option return a Payment Mismatch Error.
+- [FIXED] Reject Invalid Order Reference hooks.
 ## 2.3.5 | 01-01-2024
 Added Support for WooCommerce HPOS.
 ### Version Changes

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 == Changelog ==
+= 2.3.6 =
+* Fixed: Dynamic Adjustment to Custom Permalink Set by Merchant.
+* Fixed: Redirect Payment option return a Payment Mismatch Error.
 = 2.3.5 =
 * Added: Support for WooCommerce HPOS.
 * Fixed: WooCommerce Blocks Compatibility Issues with WooCommerce 7.0 to 6.9.1.

--- a/includes/class-flutterwave.php
+++ b/includes/class-flutterwave.php
@@ -18,7 +18,7 @@ final class Flutterwave {
 	 *
 	 * @var string
 	 */
-	public string $version = '2.3.5';
+	public string $version = '2.3.6';
 
 	/**
 	 * Plugin API version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rave-woocommerce-payment-gateway",
-	"version": "2.3.5",
+	"version": "2.3.6",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rave-woocommerce-payment-gateway",
-			"version": "2.3.5",
+			"version": "2.3.6",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "rave-woocommerce-payment-gateway",
 	"title": "flutterwave-woocommerce",
-	"version": "2.3.5",
+	"version": "2.3.6",
 	"description": "Official WooCommerce payment gateway for Flutterwave",
 	"scripts": {
 		"postinstall": "composer install",

--- a/rave-woocommerce-payment-gateway.php
+++ b/rave-woocommerce-payment-gateway.php
@@ -3,13 +3,13 @@
  * Plugin Name: Flutterwave WooCommerce
  * Plugin URI: https://developer.flutterwave.com/
  * Description: Official WooCommerce payment gateway for Flutterwave.
- * Version: 2.3.5
+ * Version: 2.3.6
  * Author: Flutterwave Developers
  * Author URI: http://flutterwave.com/us
  * License: MIT License
  * Text Domain: rave-woocommerce-payment-gateway
  * Domain Path: i18n/languages
- * WC requires at least:   6.9.1
+ * WC requires at least:   9.6.0
  * WC tested up to:        8.4.0
  * Requires at least:      5.6
  * Requires PHP:           7.4

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: theflutterwave
 Tags: fintech,flutterwave, woocommerce, payments, nigeria, mastercard, visa, target,Naira,payments,verve,donation,church,shop,store, ghana, kenya, international, mastercard, visa
 Requires at least: 3.1
-Tested up to: 6.4.2
-Stable tag: 2.3.5
+Tested up to: 6.7.1
+Stable tag: 2.3.6
 License: MIT
 License URI: https://github.com/Flutterwave/Woocommerce/blob/master/LICENSE
 
@@ -96,6 +96,9 @@ By contributing to the Flutterwave WooCommerce, you agree that your contribution
 1. You need to open an account on [Flutterwave for Business](https://dashboard.flutterwave.com)
 
 == Changelog ==
+= 2.3.6 =
+* Fixed: Dynamic Adjustment to Custom Permalink Set by Merchant.
+* Fixed: Redirect Payment option return a Payment Mismatch Error.
 = 2.3.5 =
 * Added: Support for HPOS.
 * Fixed: compatibility with WooCommerce 7.1 to 6.9.1


### PR DESCRIPTION
We need to update the compatibility of the current WordPress plugins to ensure they work seamlessly with WordPress version 6.7. The current WordPress version being used is 6.4.2, and the required version for the plugins is 6.7.

![image](https://github.com/user-attachments/assets/ba6ba61a-b607-4b39-a9af-eb06dde70574)


Acceptance Criteria:

1. Review and update plugin code to ensure compatibility with WordPress 6.7.
2. Test all existing features of the plugin to confirm functionality on WP 6.7. 
3. Ensure backward compatibility with WordPress 6.4.2, if necessary. 
4. Update plugin version to reflect compatibility with WordPress 6.7. 
5. Provide documentation on any changes made, including updates to version numbers or functionality.