### PR TITLE
add SVN installation step to package-publish.yml

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -21,6 +21,8 @@ jobs:
                 node-version-file: .nvmrc
             - name: Build Plugin
               uses: ./.github/actions/make-build
+            - name: Install SVN
+              run: sudo apt-get update && sudo apt-get install -y subversion
             - name: WordPress Plugin Deploy
               id: deploy
               uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
SVN no longer ships with ubuntu (Github actions runners) as a result svn needs to be installed before the 10up action can be used. more information [here](https://github.com/10up/action-wordpress-plugin-deploy/issues/158#issuecomment-2564633557)